### PR TITLE
Rework GUI

### DIFF
--- a/PencilChiselCode/Bonfire.cs
+++ b/PencilChiselCode/Bonfire.cs
@@ -255,5 +255,5 @@ public class Bonfire : Game
 
     public Vector2 GetWindowDimensions() => new(GetWindowWidth(), GetWindowHeight());
 
-    public Box GetRootBox() => new(this, new Vector2(0), GetWindowDimensions);
+    public AbsoluteBox GetRootBox() => new(this, new Vector2(0), GetWindowDimensions);
 }

--- a/PencilChiselCode/Source/GUI/AbsoluteBox.cs
+++ b/PencilChiselCode/Source/GUI/AbsoluteBox.cs
@@ -1,0 +1,105 @@
+using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Extended;
+
+namespace PencilChiselCode.Source.GUI;
+
+public class AbsoluteBox : Box
+{
+    public Vector2 Position { get; set; }
+    private readonly Func<Vector2> _size;
+    public Vector2 Size => _size();
+
+    public AbsoluteBox(Bonfire game, Vector2 position, Func<Vector2> size) : base(game)
+    {
+        Position = position;
+        _size = size;
+    }
+
+    public AbsoluteBox(Bonfire game, Vector2 position, Vector2 size)
+        : this(game, position, () => size) { }
+
+    public AbsoluteBox AbsoluteFrom(RelativeBox relative)
+    {
+        var absolute = new AbsoluteBox(
+            relative.Game,
+            relative.Position.RelativeTo(Size),
+            relative.Size.RelativeTo(Size)
+        )
+        {
+            IsVisible = () => relative.IsVisible() && IsVisible(),
+            DrawableElement = relative.DrawableElement,
+            Children = relative.Children
+        };
+        absolute.Position = relative.BoxAlignment switch
+        {
+            Alignments.TopLeft => Position + absolute.Position,
+            Alignments.TopCenter
+                => Position + new Vector2(Size.X / 2 + absolute.Position.X, absolute.Position.Y),
+            Alignments.TopRight
+                => Position + new Vector2(Size.X + absolute.Position.X, absolute.Position.Y),
+            Alignments.MiddleLeft
+                => Position + new Vector2(absolute.Position.X, Size.Y / 2 + absolute.Position.Y),
+            Alignments.MiddleCenter
+                => Position
+                    + new Vector2(
+                        Size.X / 2 + absolute.Position.X,
+                        Size.Y / 2 + absolute.Position.Y
+                    ),
+            Alignments.MiddleRight
+                => Position
+                    + new Vector2(Size.X + absolute.Position.X, Size.Y / 2 + absolute.Position.Y),
+            Alignments.BottomLeft
+                => Position + new Vector2(absolute.Position.X, Size.Y + absolute.Position.Y),
+            Alignments.BottomCenter
+                => Position
+                    + new Vector2(Size.X / 2 + absolute.Position.X, Size.Y + absolute.Position.Y),
+            Alignments.BottomRight
+                => Position
+                    + new Vector2(Size.X + absolute.Position.X, Size.Y + absolute.Position.Y),
+            _ => absolute.Position
+        };
+        absolute.Position += relative.SelfAlignment switch
+        {
+            Alignments.TopLeft => Vector2.Zero,
+            Alignments.TopCenter => new Vector2(-absolute.Size.X / 2, 0),
+            Alignments.TopRight => new Vector2(-absolute.Size.X, 0),
+            Alignments.MiddleLeft => new Vector2(0, -absolute.Size.Y / 2),
+            Alignments.MiddleCenter => new Vector2(-absolute.Size.X / 2, -absolute.Size.Y / 2),
+            Alignments.MiddleRight => new Vector2(-absolute.Size.X, -absolute.Size.Y / 2),
+            Alignments.BottomLeft => new Vector2(0, -absolute.Size.Y),
+            Alignments.BottomCenter => new Vector2(-absolute.Size.X / 2, -absolute.Size.Y),
+            Alignments.BottomRight => new Vector2(-absolute.Size.X, -absolute.Size.Y),
+            _ => Vector2.Zero
+        };
+        return absolute;
+    }
+
+    public void Draw(SpriteBatch spriteBatch)
+    {
+        var visible = IsVisible();
+        if (visible)
+        {
+            DrawableElement?.Draw(spriteBatch, this);
+        }
+
+        if (visible || Game.DebugMode == 2)
+        {
+            Children.ForEach(box => box.Draw(spriteBatch, this));
+        }
+
+        if (Game.DebugMode == 2 || (Game.DebugMode == 1 && visible))
+        {
+            spriteBatch.DrawRectangle(Position, Size, visible ? DebugColor : InvisibleDebugColor);
+        }
+    }
+
+    public void Update(GameTime gameTime)
+    {
+        if (!IsVisible())
+            return;
+        DrawableElement?.Update(gameTime, this);
+        Children.ForEach(box => box.Update(gameTime, this));
+    }
+}

--- a/PencilChiselCode/Source/GUI/Box.cs
+++ b/PencilChiselCode/Source/GUI/Box.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -8,155 +8,21 @@ namespace PencilChiselCode.Source.GUI;
 
 public class Box
 {
-    public readonly List<Box> Children = new();
+    public readonly Bonfire Game;
+    public List<RelativeBox> Children { get; protected set; } = new();
     public UiElement DrawableElement;
-    public Vector2 Position { get; set; }
-    public Func<Vector2> Size { get; set; }
-    public Vector2 Scale { get; set; } = new(1F);
-    public Vector2 AdjustedSize => Size() * Scale;
-    public bool IsPositionAbsolute { get; set; }
-    public bool IsSizeAbsolute { get; set; }
     public Alignments BoxAlignment { get; set; } = Alignments.TopLeft;
     public Alignments SelfAlignment { get; set; } = Alignments.TopLeft;
     public Func<bool> IsVisible { get; set; } = () => true;
     public Color DebugColor = Color.LightGreen;
     public Color InvisibleDebugColor = Color.OrangeRed;
-    public readonly Bonfire Game;
 
-    public Box(Bonfire game, Vector2 position, Func<Vector2> size)
+    public Box(Bonfire game)
     {
         Game = game;
-        Position = position;
-        Size = size;
     }
 
-    public Box(Bonfire game, Vector2 position, Vector2 size) : this(game, position, () => size) { }
+    public void AddChild(RelativeBox child) => Children.Add(child);
 
-    public Box(Bonfire game, Vector2 position, UiElement drawableElement)
-        : this(game, position, drawableElement.Size) => DrawableElement = drawableElement;
-
-    public Box(Box parent, Box child)
-    {
-        Game = child.Game;
-        Position = child.Position * (child.IsPositionAbsolute ? new(1F) : parent.AdjustedSize);
-        Size = child.IsSizeAbsolute ? child.Size : () => parent.Size() * child.Size();
-        Children = child.Children;
-        DrawableElement = child.DrawableElement;
-        IsPositionAbsolute = child.IsPositionAbsolute;
-        IsSizeAbsolute = child.IsSizeAbsolute;
-        BoxAlignment = child.BoxAlignment;
-        SelfAlignment = child.SelfAlignment;
-        IsVisible = () => child.IsVisible() && parent.IsVisible();
-        Scale = child.Scale;
-    }
-
-    public void AddChild(Box child) => Children.Add(child);
-
-    public void AddChild(params Box[] children) => Children.AddRange(children);
-
-    public void Draw(SpriteBatch spriteBatch)
-    {
-        var visible = IsVisible();
-        if (visible)
-        {
-            DrawableElement?.Draw(spriteBatch, this);
-        }
-
-        if (visible || Game.DebugMode == 2)
-        {
-            Children.ForEach(box => box.Draw(spriteBatch, this));
-        }
-
-        if (Game.DebugMode == 2 || (Game.DebugMode == 1 && visible))
-        {
-            spriteBatch.DrawRectangle(
-                Position,
-                AdjustedSize,
-                visible ? DebugColor : InvisibleDebugColor
-            );
-        }
-    }
-
-    public void Update(GameTime gameTime)
-    {
-        if (!IsVisible())
-            return;
-        DrawableElement?.Update(gameTime, this);
-        Children.ForEach(box => box.Update(gameTime, this));
-    }
-
-    public void Draw(SpriteBatch spriteBatch, Box parent)
-    {
-        if (!IsVisible() && Game.DebugMode != 2)
-            return;
-        GetAbsolute(parent).Draw(spriteBatch);
-    }
-
-    public void Update(GameTime gameTime, Box parent)
-    {
-        if (!IsVisible())
-            return;
-        GetAbsolute(parent).Update(gameTime);
-    }
-
-    public Box GetAbsolute(Box parent)
-    {
-        var abs = new Box(parent, this);
-        abs.Position = BoxAlignment switch
-        {
-            Alignments.TopLeft => parent.Position + abs.Position,
-            Alignments.TopCenter
-                => parent.Position
-                    + new Vector2(parent.AdjustedSize.X / 2 - abs.Position.X, abs.Position.Y),
-            Alignments.TopRight
-                => parent.Position
-                    + new Vector2(parent.AdjustedSize.X - abs.Position.X, abs.Position.Y),
-            Alignments.MiddleLeft
-                => parent.Position
-                    + new Vector2(abs.Position.X, parent.AdjustedSize.Y / 2 - abs.Position.Y),
-            Alignments.MiddleCenter
-                => parent.Position
-                    + new Vector2(
-                        parent.AdjustedSize.X / 2 - abs.Position.X,
-                        parent.AdjustedSize.Y / 2 - abs.Position.Y
-                    ),
-            Alignments.MiddleRight
-                => parent.Position
-                    + new Vector2(
-                        parent.AdjustedSize.X - abs.Position.X,
-                        parent.AdjustedSize.Y / 2 - abs.Position.Y
-                    ),
-            Alignments.BottomLeft
-                => parent.Position
-                    + new Vector2(abs.Position.X, parent.AdjustedSize.Y - abs.Position.Y),
-            Alignments.BottomCenter
-                => parent.Position
-                    + new Vector2(
-                        parent.AdjustedSize.X / 2 - abs.Position.X,
-                        parent.AdjustedSize.Y - abs.Position.Y
-                    ),
-            Alignments.BottomRight
-                => parent.Position
-                    + new Vector2(
-                        parent.AdjustedSize.X - abs.Position.X,
-                        parent.AdjustedSize.Y - abs.Position.Y
-                    ),
-            _ => abs.Position
-        };
-        abs.Position += SelfAlignment switch
-        {
-            Alignments.TopLeft => Vector2.Zero,
-            Alignments.TopCenter => new Vector2(-abs.AdjustedSize.X / 2, 0),
-            Alignments.TopRight => new Vector2(-abs.AdjustedSize.X, 0),
-            Alignments.MiddleLeft => new Vector2(0, -abs.AdjustedSize.Y / 2),
-            Alignments.MiddleCenter
-                => new Vector2(-abs.AdjustedSize.X / 2, -abs.AdjustedSize.Y / 2),
-            Alignments.MiddleRight => new Vector2(-abs.AdjustedSize.X, -abs.AdjustedSize.Y / 2),
-            Alignments.BottomLeft => new Vector2(0, -abs.AdjustedSize.Y),
-            Alignments.BottomCenter => new Vector2(-abs.AdjustedSize.X / 2, -abs.AdjustedSize.Y),
-            Alignments.BottomRight => new Vector2(-abs.AdjustedSize.X, -abs.AdjustedSize.Y),
-            _ => Vector2.Zero
-        };
-        return abs;
-    }
+    public void AddChild(params RelativeBox[] children) => Children.AddRange(children);
 }

--- a/PencilChiselCode/Source/GUI/Button.cs
+++ b/PencilChiselCode/Source/GUI/Button.cs
@@ -19,10 +19,10 @@ public abstract class Button : UiElement
         ReleaseSound = releaseSound;
     }
 
-    public override void Update(GameTime gameTime, Box parent)
+    public override void Update(GameTime gameTime, AbsoluteBox parent)
     {
         var mouse = parent.Game.MouseValues;
-        var region = new Rectangle(parent.Position.ToPoint(), parent.Size().ToPoint());
+        var region = new Rectangle(parent.Position.ToPoint(), parent.Size.ToPoint());
         IsHighlighted = Utils.IsPointInRectangle(mouse.CurrentState.Position.ToVector2(), region);
         if (mouse.JustExited(region))
         {
@@ -43,14 +43,14 @@ public abstract class Button : UiElement
         }
     }
 
-    public override void OnUnhovered(Box parent)
+    public override void OnUnhovered(AbsoluteBox parent)
     {
         if (IsPressed)
             ReleaseSound.Play();
         IsPressed = false;
     }
 
-    public override void OnClick(Box parent, MouseButton button)
+    public override void OnClick(AbsoluteBox parent, MouseButton button)
     {
         if (button != MouseButton.Left || !IsHighlighted)
             return;
@@ -58,7 +58,7 @@ public abstract class Button : UiElement
         IsPressed = true;
     }
 
-    public override void OnRelease(Box parent, MouseButton button)
+    public override void OnRelease(AbsoluteBox parent, MouseButton button)
     {
         if (button != MouseButton.Left || !IsPressed || !IsHighlighted)
             return;

--- a/PencilChiselCode/Source/GUI/IUIElement.cs
+++ b/PencilChiselCode/Source/GUI/IUIElement.cs
@@ -6,15 +6,15 @@ namespace PencilChiselCode.Source.GUI;
 public abstract class UiElement
 {
     public abstract Vector2 Size();
-    public abstract void Draw(SpriteBatch spriteBatch, Box parent);
+    public abstract void Draw(SpriteBatch spriteBatch, AbsoluteBox parent);
 
-    public virtual void Update(GameTime gameTime, Box parent) { }
+    public virtual void Update(GameTime gameTime, AbsoluteBox parent) { }
 
-    public virtual void OnClick(Box parent, MouseButton button) { }
+    public virtual void OnClick(AbsoluteBox parent, MouseButton button) { }
 
-    public virtual void OnRelease(Box parent, MouseButton button) { }
+    public virtual void OnRelease(AbsoluteBox parent, MouseButton button) { }
 
-    public virtual void OnHovered(Box parent) { }
+    public virtual void OnHovered(AbsoluteBox parent) { }
 
-    public virtual void OnUnhovered(Box parent) { }
+    public virtual void OnUnhovered(AbsoluteBox parent) { }
 }

--- a/PencilChiselCode/Source/GUI/Menus.cs
+++ b/PencilChiselCode/Source/GUI/Menus.cs
@@ -5,249 +5,177 @@ namespace PencilChiselCode.Source.GUI;
 
 public static class Menus
 {
-    public static Box GetSettingsMenu(Bonfire game, Action onDoneClick)
+    public static RelativeBox GetSettingsMenu(Bonfire game, Action onDoneClick)
     {
         var page = 0;
         const float categoriesSize = 0.25F;
-        var settingsMenu = new Box(game, new Vector2(0), new Vector2(0.66F))
+        var settingsMenu = new RelativeBox(game, 0, 0.66F)
         {
-            IsPositionAbsolute = true,
             BoxAlignment = Alignments.MiddleCenter,
             SelfAlignment = Alignments.MiddleCenter
         };
-        var menuCategories = new Box(game, new Vector2(0), new Vector2(categoriesSize, 1F))
+        var menuCategories = new RelativeBox(game, 0, (categoriesSize, 1F))
         {
             BoxAlignment = Alignments.MiddleLeft,
             SelfAlignment = Alignments.MiddleLeft
         };
+        var videoElement = new TextButton(
+            new UiTextElement(game.FontMap["32"], () => "Video", Color.White, Color.Black),
+            new UiTextElement(game.FontMap["32"], () => "Video", Color.Red, Color.Black),
+            new UiTextElement(game.FontMap["32"], () => "Video", Color.Green, Color.Black),
+            game.SoundMap["button_press"],
+            game.SoundMap["button_release"],
+            () => page = 0
+        );
+        var audioElement = new TextButton(
+            new UiTextElement(game.FontMap["32"], () => "Audio", Color.White, Color.Black),
+            new UiTextElement(game.FontMap["32"], () => "Audio", Color.Red, Color.Black),
+            new UiTextElement(game.FontMap["32"], () => "Audio", Color.Green, Color.Black),
+            game.SoundMap["button_press"],
+            game.SoundMap["button_release"],
+            () => page = 1
+        );
+        var controlsElement = new TextButton(
+            new UiTextElement(game.FontMap["32"], () => "Controls", Color.White, Color.Black),
+            new UiTextElement(game.FontMap["32"], () => "Controls", Color.Red, Color.Black),
+            new UiTextElement(game.FontMap["32"], () => "Controls", Color.Green, Color.Black),
+            game.SoundMap["button_press"],
+            game.SoundMap["button_release"],
+            () => page = 2
+        );
+        var doneElement = new TextButton(
+            new UiTextElement(game.FontMap["32"], () => "Done", Color.White, Color.Black),
+            new UiTextElement(game.FontMap["32"], () => "Done", Color.Red, Color.Black),
+            new UiTextElement(game.FontMap["32"], () => "Done", Color.Green, Color.Black),
+            game.SoundMap["button_press"],
+            game.SoundMap["button_release"],
+            onDoneClick
+        );
         menuCategories.AddChild(
-            new Box(
-                game,
-                new Vector2(16),
-                new TextButton(
-                    new UiTextElement(game.FontMap["32"], () => "Video", Color.White, Color.Black),
-                    new UiTextElement(game.FontMap["32"], () => "Video", Color.Red, Color.Black),
-                    new UiTextElement(game.FontMap["32"], () => "Video", Color.Green, Color.Black),
-                    game.SoundMap["button_press"],
-                    game.SoundMap["button_release"],
-                    () => page = 0
-                )
-            )
+            new RelativeBox(game, 16, videoElement.Size()) { DrawableElement = videoElement },
+            new RelativeBox(game, (16, 64), audioElement.Size()) { DrawableElement = audioElement },
+            new RelativeBox(game, (16, 112), controlsElement.Size())
             {
-                IsPositionAbsolute = true,
-                IsSizeAbsolute = true
+                DrawableElement = controlsElement
             },
-            new Box(
-                game,
-                new Vector2(16, 64),
-                new TextButton(
-                    new UiTextElement(game.FontMap["32"], () => "Audio", Color.White, Color.Black),
-                    new UiTextElement(game.FontMap["32"], () => "Audio", Color.Red, Color.Black),
-                    new UiTextElement(game.FontMap["32"], () => "Audio", Color.Green, Color.Black),
-                    game.SoundMap["button_press"],
-                    game.SoundMap["button_release"],
-                    () => page = 1
-                )
-            )
+            new RelativeBox(game, 16, doneElement.Size())
             {
-                IsPositionAbsolute = true,
-                IsSizeAbsolute = true
-            },
-            new Box(
-                game,
-                new Vector2(16, 112),
-                new TextButton(
-                    new UiTextElement(
-                        game.FontMap["32"],
-                        () => "Controls",
-                        Color.White,
-                        Color.Black
-                    ),
-                    new UiTextElement(game.FontMap["32"], () => "Controls", Color.Red, Color.Black),
-                    new UiTextElement(
-                        game.FontMap["32"],
-                        () => "Controls",
-                        Color.Green,
-                        Color.Black
-                    ),
-                    game.SoundMap["button_press"],
-                    game.SoundMap["button_release"],
-                    () => page = 2
-                )
-            )
-            {
-                IsPositionAbsolute = true,
-                IsSizeAbsolute = true
-            },
-            new Box(
-                game,
-                new Vector2(16),
-                new TextButton(
-                    new UiTextElement(game.FontMap["32"], () => "Done", Color.White, Color.Black),
-                    new UiTextElement(game.FontMap["32"], () => "Done", Color.Red, Color.Black),
-                    new UiTextElement(game.FontMap["32"], () => "Done", Color.Green, Color.Black),
-                    game.SoundMap["button_press"],
-                    game.SoundMap["button_release"],
-                    onDoneClick
-                )
-            )
-            {
-                IsPositionAbsolute = true,
-                IsSizeAbsolute = true,
                 BoxAlignment = Alignments.BottomLeft,
-                SelfAlignment = Alignments.BottomLeft
+                SelfAlignment = Alignments.BottomLeft,
+                DrawableElement = doneElement
             }
         );
         settingsMenu.AddChild(menuCategories);
-        var videoMenu = new Box(
-            game,
-            new Vector2(categoriesSize, 0F),
-            new Vector2(1 - categoriesSize, 1F)
-        )
+        var videoMenu = new RelativeBox(game, (categoriesSize, 0F), (1F - categoriesSize, 1F))
         {
             BoxAlignment = Alignments.MiddleLeft,
             SelfAlignment = Alignments.MiddleLeft,
             IsVisible = () => page == 0
         };
-        videoMenu.AddChild(
-            new Box(
-                game,
-                new Vector2(16),
-                new UiTextElement(
-                    game.FontMap["24"],
-                    () => "Resolution",
-                    Color.LimeGreen,
-                    Color.Green
-                )
-            )
-            {
-                IsPositionAbsolute = true,
-                IsSizeAbsolute = true
-            },
-            new Box(
-                game,
-                new Vector2(16, 48),
-                new UiTextElement(game.FontMap["24"], () => "VSync", Color.LimeGreen, Color.Green)
-            )
-            {
-                IsPositionAbsolute = true,
-                IsSizeAbsolute = true
-            }
+        var resolutionElement = new UiTextElement(
+            game.FontMap["24"],
+            () => "Resolution",
+            Color.LimeGreen,
+            Color.Green
         );
-        var soundMenu = new Box(
-            game,
-            new Vector2(categoriesSize, 0F),
-            new Vector2(1 - categoriesSize, 1F)
-        )
+        var vsyncElement = new UiTextElement(
+            game.FontMap["24"],
+            () => "VSync",
+            Color.LimeGreen,
+            Color.Green
+        );
+        videoMenu.AddChild(
+            new RelativeBox(game, 16, resolutionElement.Size())
+            {
+                DrawableElement = resolutionElement
+            },
+            new RelativeBox(game, (16, 48), vsyncElement.Size()) { DrawableElement = vsyncElement }
+        );
+        var soundMenu = new RelativeBox(game, (categoriesSize, 0F), (1 - categoriesSize, 1F))
         {
             BoxAlignment = Alignments.MiddleLeft,
             SelfAlignment = Alignments.MiddleLeft,
             IsVisible = () => page == 1
         };
-        soundMenu.AddChild(
-            new Box(
-                game,
-                new Vector2(16),
-                new UiTextElement(
-                    game.FontMap["24"],
-                    () => "Master Volume",
-                    Color.LimeGreen,
-                    Color.Green
-                )
-            )
-            {
-                IsPositionAbsolute = true,
-                IsSizeAbsolute = true
-            },
-            new Box(
-                game,
-                new Vector2(16, 48),
-                new UiTextElement(game.FontMap["24"], () => "Music", Color.LimeGreen, Color.Green)
-            )
-            {
-                IsPositionAbsolute = true,
-                IsSizeAbsolute = true
-            },
-            new Box(
-                game,
-                new Vector2(16, 80),
-                new UiTextElement(game.FontMap["24"], () => "SFX", Color.LimeGreen, Color.Green)
-            )
-            {
-                IsPositionAbsolute = true,
-                IsSizeAbsolute = true
-            }
+        var masterVolumeElement = new UiTextElement(
+            game.FontMap["24"],
+            () => "Master Volume",
+            Color.LimeGreen,
+            Color.Green
         );
-        var controlsMenu = new Box(
-            game,
-            new Vector2(categoriesSize, 0F),
-            new Vector2(1 - categoriesSize, 1F)
-        )
+        var musicElement = new UiTextElement(
+            game.FontMap["24"],
+            () => "Music",
+            Color.LimeGreen,
+            Color.Green
+        );
+        var sfxElement = new UiTextElement(
+            game.FontMap["24"],
+            () => "SFX",
+            Color.LimeGreen,
+            Color.Green
+        );
+        soundMenu.AddChild(
+            new RelativeBox(game, 16, masterVolumeElement.Size())
+            {
+                DrawableElement = masterVolumeElement
+            },
+            new RelativeBox(game, (16, 48), musicElement.Size()) { DrawableElement = musicElement },
+            new RelativeBox(game, (16, 80), sfxElement.Size()) { DrawableElement = sfxElement }
+        );
+        var controlsMenu = new RelativeBox(game, (categoriesSize, 0F), (1 - categoriesSize, 1F))
         {
             BoxAlignment = Alignments.MiddleLeft,
             SelfAlignment = Alignments.MiddleLeft,
             IsVisible = () => page == 2
         };
+        var collectElement = new UiTextElement(
+            game.FontMap["24"],
+            () => "Collect",
+            Color.LimeGreen,
+            Color.Green
+        );
+        var moveUpElement = new UiTextElement(
+            game.FontMap["24"],
+            () => "Move Up",
+            Color.LimeGreen,
+            Color.Green
+        );
+        var moveDownElement = new UiTextElement(
+            game.FontMap["24"],
+            () => "Move Down",
+            Color.LimeGreen,
+            Color.Green
+        );
+        var moveLeftElement = new UiTextElement(
+            game.FontMap["24"],
+            () => "Move Left",
+            Color.LimeGreen,
+            Color.Green
+        );
+        var moveRightElement = new UiTextElement(
+            game.FontMap["24"],
+            () => "Move Right",
+            Color.LimeGreen,
+            Color.Green
+        );
         controlsMenu.AddChild(
-            new Box(
-                game,
-                new Vector2(16),
-                new UiTextElement(game.FontMap["24"], () => "Collect", Color.LimeGreen, Color.Green)
-            )
+            new RelativeBox(game, 16, collectElement.Size()) { DrawableElement = collectElement },
+            new RelativeBox(game, (16, 48), moveUpElement.Size())
             {
-                IsPositionAbsolute = true,
-                IsSizeAbsolute = true
+                DrawableElement = moveUpElement
             },
-            new Box(
-                game,
-                new Vector2(16, 48),
-                new UiTextElement(game.FontMap["24"], () => "Move Up", Color.LimeGreen, Color.Green)
-            )
+            new RelativeBox(game, (16, 80), moveDownElement.Size())
             {
-                IsPositionAbsolute = true,
-                IsSizeAbsolute = true
+                DrawableElement = moveDownElement
             },
-            new Box(
-                game,
-                new Vector2(16, 80),
-                new UiTextElement(
-                    game.FontMap["24"],
-                    () => "Move Down",
-                    Color.LimeGreen,
-                    Color.Green
-                )
-            )
+            new RelativeBox(game, (16, 112), moveLeftElement.Size())
             {
-                IsPositionAbsolute = true,
-                IsSizeAbsolute = true
+                DrawableElement = moveLeftElement
             },
-            new Box(
-                game,
-                new Vector2(16, 112),
-                new UiTextElement(
-                    game.FontMap["24"],
-                    () => "Move Left",
-                    Color.LimeGreen,
-                    Color.Green
-                )
-            )
+            new RelativeBox(game, (16, 144), moveRightElement.Size())
             {
-                IsPositionAbsolute = true,
-                IsSizeAbsolute = true
-            },
-            new Box(
-                game,
-                new Vector2(16, 144),
-                new UiTextElement(
-                    game.FontMap["24"],
-                    () => "Move Right",
-                    Color.LimeGreen,
-                    Color.Green
-                )
-            )
-            {
-                IsPositionAbsolute = true,
-                IsSizeAbsolute = true
+                DrawableElement = moveRightElement
             }
         );
         settingsMenu.AddChild(videoMenu, soundMenu, controlsMenu);

--- a/PencilChiselCode/Source/GUI/RelativeBox.cs
+++ b/PencilChiselCode/Source/GUI/RelativeBox.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace PencilChiselCode.Source.GUI;
+
+public class RelativeBox : Box
+{
+    public ScalarVector2 Position { get; set; }
+    public ScalarVector2 Size { get; set; }
+
+    public RelativeBox(Bonfire game, ScalarVector2 position, ScalarVector2 size) : base(game)
+    {
+        Position = position;
+        Size = size;
+    }
+
+    public void Draw(SpriteBatch spriteBatch, AbsoluteBox parent)
+    {
+        if (!IsVisible() && Game.DebugMode != 2)
+            return;
+        parent.AbsoluteFrom(this).Draw(spriteBatch);
+    }
+
+    public void Update(GameTime gameTime, AbsoluteBox parent)
+    {
+        if (!IsVisible())
+            return;
+        parent.AbsoluteFrom(this).Update(gameTime);
+    }
+}

--- a/PencilChiselCode/Source/GUI/Scalar.cs
+++ b/PencilChiselCode/Source/GUI/Scalar.cs
@@ -1,0 +1,229 @@
+using System;
+using Microsoft.Xna.Framework;
+
+namespace PencilChiselCode.Source.GUI;
+
+public abstract record Scalar;
+
+public record Pixels : Scalar
+{
+    public int Value { get; }
+
+    public Pixels(int Value) => this.Value = Value;
+
+    public static implicit operator Pixels(int value) => new(value);
+
+    public static Pixels operator +(Pixels pixels, int value) => new(pixels.Value + value);
+
+    public static Pixels operator -(Pixels pixels, int value) => new(pixels.Value - value);
+
+    public static Pixels operator *(Pixels pixels, int value) => value * pixels;
+
+    public static Pixels operator *(int value, Pixels pixels) => new(value * pixels.Value);
+
+    public static Pixels operator /(Pixels pixels, int value) => new(pixels.Value / value);
+
+    public static Pixels operator +(Pixels pixels1, Pixels pixels2) =>
+        new(pixels1.Value + pixels2.Value);
+
+    public static Pixels operator -(Pixels pixels1, Pixels pixels2) =>
+        new(pixels1.Value - pixels2.Value);
+
+    public static Percent operator /(Pixels pixels1, Pixels pixels2) =>
+        new((float)pixels1.Value / pixels2.Value);
+
+    public static Pixels operator *(Pixels pixels, float value) => new((int)(pixels.Value * value));
+
+    public static Pixels operator *(float value, Pixels pixels) => pixels * value;
+
+    public static Pixels operator /(Pixels pixels, float value) => new((int)(pixels.Value / value));
+
+    public static Pixels operator +(Pixels pixels, Percent percent) =>
+        new((int)(pixels.Value * (1 + percent.Value)));
+
+    public static Pixels operator -(Pixels pixels, Percent percent) =>
+        new((int)(pixels.Value * (1 - percent.Value)));
+
+    public static Pixels operator *(Pixels pixels, Percent percent) =>
+        new((int)(pixels.Value * percent.Value));
+
+    public static Pixels operator *(Percent percent, Pixels pixels) => pixels * percent;
+
+    public static Pixels operator *(Pixels pixels, Ratio ratio) =>
+        new((int)(pixels.Value * ratio.Value));
+
+    public static Pixels operator *(Ratio ratio, Pixels pixels) => pixels * ratio;
+}
+
+public record Percent : Scalar
+{
+    public float Value { get; }
+
+    public Percent(float Value) => this.Value = Value;
+
+    public static implicit operator Percent(float value) => new(value);
+}
+
+public record Ratio : Scalar
+{
+    public float Value { get; }
+
+    public Ratio(float Value) => this.Value = Value;
+}
+
+public class ScalarVector2
+{
+    public Scalar X { get; }
+    public Scalar Y { get; }
+
+    public ScalarVector2(Scalar X, Scalar Y)
+    {
+        this.X = X;
+        this.Y = Y;
+    }
+
+    public ScalarVector2(int X, int Y) : this(new Pixels(X), new Pixels(Y)) { }
+
+    public ScalarVector2((int X, int Y) value) : this(value.X, value.Y) { }
+
+    public ScalarVector2(int value) : this(new Pixels(value), new Pixels(value)) { }
+
+    public ScalarVector2(float value) : this(new Percent(value), new Percent(value)) { }
+
+    public ScalarVector2(float X, float Y) : this(new Percent(X), new Percent(Y)) { }
+
+    public ScalarVector2((float X, float Y) value) : this(value.X, value.Y) { }
+
+    public ScalarVector2(int X, float Y) : this(new Pixels(X), new Percent(Y)) { }
+
+    public ScalarVector2((int X, float Y) value) : this(value.X, value.Y) { }
+
+    public ScalarVector2(float X, int Y) : this(new Percent(X), new Pixels(Y)) { }
+
+    public ScalarVector2((float X, int Y) value) : this(value.X, value.Y) { }
+
+    public ScalarVector2(int X, Ratio Y) : this(new Pixels(X), Y) { }
+
+    public ScalarVector2((int X, Ratio Y) value) : this(value.X, value.Y) { }
+
+    public ScalarVector2(Ratio X, int Y) : this(X, new Pixels(Y)) { }
+
+    public ScalarVector2((Ratio X, int Y) value) : this(value.X, value.Y) { }
+
+    public ScalarVector2(float X, Ratio Y) : this(new Percent(X), Y) { }
+
+    public ScalarVector2((float X, Ratio Y) value) : this(value.X, value.Y) { }
+
+    public ScalarVector2(Ratio X, float Y) : this(X, new Percent(Y)) { }
+
+    public ScalarVector2((Ratio X, float Y) value) : this(value.X, value.Y) { }
+
+    public ScalarVector2(Scalar value) : this(value, value) { }
+
+    public ScalarVector2((Scalar, Scalar) tuple) : this(tuple.Item1, tuple.Item2) { }
+
+    public ScalarVector2(Vector2 vector2)
+        : this(new Pixels((int)vector2.X), new Pixels((int)vector2.Y)) { }
+
+    public static implicit operator ScalarVector2((Scalar, Scalar) tuple) => new(tuple);
+
+    // up for debate
+    public static implicit operator ScalarVector2(Vector2 vector2) => new(vector2);
+
+    public static implicit operator Vector2(ScalarVector2 scalarVector2) =>
+        scalarVector2.ToAbsoluteVector2Safe();
+
+    public static implicit operator ScalarVector2(int value) => new(value);
+
+    public static implicit operator ScalarVector2(float value) => new(value);
+
+    public static implicit operator ScalarVector2((int, int) tuple) => new(tuple);
+
+    public static implicit operator ScalarVector2((float, float) tuple) => new(tuple);
+
+    public static implicit operator ScalarVector2((int, float) tuple) => new(tuple);
+
+    public static implicit operator ScalarVector2((float, int) tuple) => new(tuple);
+
+    public static implicit operator ScalarVector2((int, Ratio) tuple) => new(tuple);
+
+    public static implicit operator ScalarVector2((Ratio, int) tuple) => new(tuple);
+
+    public static implicit operator ScalarVector2((float, Ratio) tuple) => new(tuple);
+
+    public static implicit operator ScalarVector2((Ratio, float) tuple) => new(tuple);
+
+    public static ScalarVector2 operator *(ScalarVector2 scalarVector2, float scalar) =>
+        scalarVector2 switch
+        {
+            { X: Pixels x, Y: Pixels y } => (x * scalar, y * scalar),
+            _ => throw new NotImplementedException()
+        };
+
+    public static ScalarVector2 operator *(float scalar, ScalarVector2 scalarVector2) =>
+        scalarVector2 * scalar;
+
+    public static ScalarVector2 operator *(ScalarVector2 scalarVector2, Percent percent) =>
+        scalarVector2 switch
+        {
+            { X: Pixels x, Y: Pixels y } => (x * percent, y * percent),
+            _ => throw new NotImplementedException()
+        };
+
+    public static ScalarVector2 operator *(Percent percent, ScalarVector2 scalarVector2) =>
+        scalarVector2 * percent;
+
+    public ScalarVector2 RelativeTo(ScalarVector2 parent)
+    {
+        if (!(parent.X is Pixels && parent.Y is Pixels))
+        {
+            throw new InvalidOperationException("Parent must be in pixels");
+        }
+        var parentX = (Pixels)parent.X;
+        var parentY = (Pixels)parent.Y;
+        return new(
+            this switch
+            {
+                { X: Pixels x, Y: Pixels y } => (x, y),
+                { X: Percent x, Y: Percent y } => (parentX * x, parentY * y),
+                { X: Percent x, Y: Pixels y } => (parentX * x, y),
+                { X: Pixels x, Y: Percent y } => (x, parentY * y),
+                { X: Ratio x, Y: Pixels y } => (y * x, y),
+                { X: Pixels x, Y: Ratio y } => (x, x * y),
+                { X: Ratio x, Y: Percent y } => (y * parentY * x, y * parentY),
+                { X: Percent x, Y: Ratio y } => (x * parentX, x * parentX * y),
+                { X: Ratio _, Y: Ratio _ }
+                    => throw new InvalidOperationException("Cannot have 2 ratios"),
+                _ => throw new NotImplementedException()
+            }
+        );
+    }
+
+    public Vector2 ToVector2()
+    {
+        var x = X switch
+        {
+            Pixels pixels => pixels.Value,
+            Percent percent => percent.Value,
+            Ratio ratio => ratio.Value,
+            _ => throw new NotImplementedException()
+        };
+        var y = Y switch
+        {
+            Pixels pixels => pixels.Value,
+            Percent percent => percent.Value,
+            Ratio ratio => ratio.Value,
+            _ => throw new NotImplementedException()
+        };
+        return new(x, y);
+    }
+
+    public Vector2 ToAbsoluteVector2Safe()
+    {
+        if (X is Pixels x && Y is Pixels y)
+        {
+            return new(x.Value, y.Value);
+        }
+        throw new InvalidOperationException("Cannot convert to absolute vector2");
+    }
+}

--- a/PencilChiselCode/Source/GUI/TextButton.cs
+++ b/PencilChiselCode/Source/GUI/TextButton.cs
@@ -34,6 +34,6 @@ public class TextButton : Button
         _pressedTextElement = pressed;
     }
 
-    public override void Draw(SpriteBatch spriteBatch, Box parent) =>
+    public override void Draw(SpriteBatch spriteBatch, AbsoluteBox parent) =>
         TextElement.Draw(spriteBatch, parent);
 }

--- a/PencilChiselCode/Source/GUI/TexturedButton.cs
+++ b/PencilChiselCode/Source/GUI/TexturedButton.cs
@@ -34,7 +34,7 @@ public class TexturedButton : Button
         _pressedTexture = pressed;
     }
 
-    public override void Draw(SpriteBatch spriteBatch, Box parent) =>
+    public override void Draw(SpriteBatch spriteBatch, AbsoluteBox parent) =>
         spriteBatch.Draw(
             Texture,
             parent.Position,
@@ -42,7 +42,7 @@ public class TexturedButton : Button
             Color.White,
             0F,
             Vector2.Zero,
-            parent.Scale,
+            parent.Size / Size(),
             SpriteEffects.None,
             0F
         );

--- a/PencilChiselCode/Source/GUI/UiTextElement.cs
+++ b/PencilChiselCode/Source/GUI/UiTextElement.cs
@@ -27,7 +27,7 @@ public class UiTextElement : UiElement
         OutlineColor = outlineColor ?? Color.Black;
     }
 
-    public override void Draw(SpriteBatch spriteBatch, Box parent)
+    public override void Draw(SpriteBatch spriteBatch, AbsoluteBox parent)
     {
         if (OutlineColor.HasValue)
         {

--- a/PencilChiselCode/Source/GUI/UiTextureElement.cs
+++ b/PencilChiselCode/Source/GUI/UiTextureElement.cs
@@ -8,11 +8,13 @@ public class UiTextureElement : UiElement
     public override Vector2 Size() => new(_texture.Width, _texture.Height);
 
     private readonly Texture2D _texture;
+
     public Color Color { get; set; } = Color.White;
 
     public UiTextureElement(Texture2D texture) => _texture = texture;
 
-    public override void Draw(SpriteBatch spriteBatch, Box parent) =>
+    public override void Draw(SpriteBatch spriteBatch, AbsoluteBox parent)
+    {
         spriteBatch.Draw(
             _texture,
             parent.Position,
@@ -20,8 +22,9 @@ public class UiTextureElement : UiElement
             Color,
             0F,
             Vector2.Zero,
-            parent.Scale,
+            parent.Size / Size(),
             SpriteEffects.None,
             0F
         );
+    }
 }

--- a/PencilChiselCode/Source/GameStates/IngameState.cs
+++ b/PencilChiselCode/Source/GameStates/IngameState.cs
@@ -40,7 +40,7 @@ public class IngameState : BonfireGameState
     private const int SpawnOffset = 128;
     public const int DarknessEndOffset = 64;
     public OrthographicCamera Camera { get; private set; }
-    public Box RootBox;
+    public AbsoluteBox RootBox;
 
     private int MapIndex =>
         (int)Math.Abs(Math.Floor(Camera.GetViewMatrix().Translation.X / _maps[0].HeightInPixels));
@@ -142,40 +142,36 @@ public class IngameState : BonfireGameState
         );
 
         RootBox = Game.GetRootBox();
-        var buttonBox = new Box(Game, new Vector2(0F, 0F), new Vector2(0.5F))
+        var buttonBox = new RelativeBox(Game, 0, 0.5F)
         {
-            IsPositionAbsolute = true,
             BoxAlignment = Alignments.MiddleCenter,
             SelfAlignment = Alignments.MiddleCenter
         };
         buttonBox.AddChild(
-            new Box(Game, new Vector2(0F, 80F), resumeButton)
+            new RelativeBox(Game, (0, -80), resumeButton.Size())
             {
-                IsSizeAbsolute = true,
-                IsPositionAbsolute = true,
                 BoxAlignment = Alignments.BottomCenter,
                 SelfAlignment = Alignments.BottomCenter,
-                IsVisible = () => _pauseState
+                IsVisible = () => _pauseState,
+                DrawableElement = resumeButton
             }
         );
         buttonBox.AddChild(
-            new Box(Game, new Vector2(0F), menuButton)
+            new RelativeBox(Game, 0, menuButton.Size())
             {
-                IsSizeAbsolute = true,
-                IsPositionAbsolute = true,
                 BoxAlignment = Alignments.BottomCenter,
                 SelfAlignment = Alignments.BottomCenter,
-                IsVisible = () => _pauseState || _deathState
+                IsVisible = () => _pauseState || _deathState,
+                DrawableElement = menuButton
             }
         );
         buttonBox.AddChild(
-            new Box(Game, new Vector2(0F, 80F), restartButton)
+            new RelativeBox(Game, (0, -80), restartButton.Size())
             {
-                IsSizeAbsolute = true,
-                IsPositionAbsolute = true,
                 BoxAlignment = Alignments.BottomCenter,
                 SelfAlignment = Alignments.BottomCenter,
-                IsVisible = () => _deathState
+                IsVisible = () => _deathState,
+                DrawableElement = restartButton
             }
         );
         RootBox.AddChild(buttonBox);
@@ -186,20 +182,18 @@ public class IngameState : BonfireGameState
             Color.Red,
             Color.Black
         );
-        var textInfoBox = new Box(Game, new Vector2(0F, 0F), new Vector2(0.5F, 0.25F))
+        var textInfoBox = new RelativeBox(Game, 0, (0.5F, 0.25F))
         {
-            IsPositionAbsolute = true,
             BoxAlignment = Alignments.MiddleCenter,
             SelfAlignment = Alignments.MiddleCenter,
         };
         textInfoBox.AddChild(
-            new Box(Game, new Vector2(0F), gameOverText)
+            new RelativeBox(Game, 0, gameOverText.Size())
             {
-                IsSizeAbsolute = true,
-                IsPositionAbsolute = true,
                 BoxAlignment = Alignments.TopCenter,
                 SelfAlignment = Alignments.TopCenter,
-                IsVisible = () => _deathState
+                IsVisible = () => _deathState,
+                DrawableElement = gameOverText
             }
         );
         var finalScoreText = new UiTextElement(
@@ -210,13 +204,12 @@ public class IngameState : BonfireGameState
             Color.Black
         );
         textInfoBox.AddChild(
-            new Box(Game, new Vector2(0F, 50F), finalScoreText)
+            new RelativeBox(Game, (0, 50), finalScoreText.Size())
             {
-                IsSizeAbsolute = true,
-                IsPositionAbsolute = true,
                 BoxAlignment = Alignments.TopCenter,
                 SelfAlignment = Alignments.TopCenter,
-                IsVisible = () => _deathState || _pauseState
+                IsVisible = () => _deathState || _pauseState,
+                DrawableElement = finalScoreText
             }
         );
         RootBox.AddChild(textInfoBox);

--- a/PencilChiselCode/Source/GameStates/MenuState.cs
+++ b/PencilChiselCode/Source/GameStates/MenuState.cs
@@ -6,7 +6,7 @@ namespace PencilChiselCode.Source.GameStates;
 
 public class MenuState : BonfireGameState
 {
-    public Box RootBox;
+    public AbsoluteBox RootBox;
 
     public MenuState(Game game) : base(game) =>
         BgColor = new Color(9F / 255F, 10F / 255F, 20F / 255F);
@@ -18,26 +18,22 @@ public class MenuState : BonfireGameState
         RootBox = Game.GetRootBox();
         var logo = new UiTextureElement(textureMap["logo"]);
         var showSettings = false;
-        var menuBox = new Box(Game, new Vector2(0F), new Vector2(0.75F))
+        var menuBox = new RelativeBox(Game, 0, 0.75F)
         {
-            IsVisible = () => !showSettings,
-            IsPositionAbsolute = true,
             BoxAlignment = Alignments.MiddleCenter,
-            SelfAlignment = Alignments.MiddleCenter
+            SelfAlignment = Alignments.MiddleCenter,
+            IsVisible = () => !showSettings
         };
         menuBox.AddChild(
-            new Box(Game, new Vector2(0F, 120F), logo)
+            new RelativeBox(Game, (0, 120), logo.Size() * 2.5F)
             {
-                IsSizeAbsolute = true,
-                IsPositionAbsolute = true,
                 BoxAlignment = Alignments.TopCenter,
                 SelfAlignment = Alignments.MiddleCenter,
-                Scale = new(2.5F)
+                DrawableElement = logo
             }
         );
-        var buttonBox = new Box(Game, new Vector2(0F), new Vector2(0.75F))
+        var buttonBox = new RelativeBox(Game, 0, 0.75F)
         {
-            IsPositionAbsolute = true,
             BoxAlignment = Alignments.BottomCenter,
             SelfAlignment = Alignments.BottomCenter
         };
@@ -50,12 +46,11 @@ public class MenuState : BonfireGameState
             Game.Start
         );
         buttonBox.AddChild(
-            new Box(Game, new Vector2(0), startButton)
+            new RelativeBox(Game, 0, startButton.Size())
             {
-                IsSizeAbsolute = true,
-                IsPositionAbsolute = true,
                 BoxAlignment = Alignments.MiddleCenter,
-                SelfAlignment = Alignments.MiddleCenter
+                SelfAlignment = Alignments.MiddleCenter,
+                DrawableElement = startButton
             }
         );
         var settingsButton = new TexturedButton(
@@ -67,12 +62,11 @@ public class MenuState : BonfireGameState
             () => showSettings = true
         );
         buttonBox.AddChild(
-            new Box(Game, new Vector2(0F, -85F), settingsButton)
+            new RelativeBox(Game, (0, 85), settingsButton.Size())
             {
-                IsSizeAbsolute = true,
-                IsPositionAbsolute = true,
                 BoxAlignment = Alignments.MiddleCenter,
-                SelfAlignment = Alignments.MiddleCenter
+                SelfAlignment = Alignments.MiddleCenter,
+                DrawableElement = settingsButton
             }
         );
         var exitButton = new TexturedButton(
@@ -84,12 +78,11 @@ public class MenuState : BonfireGameState
             Game.Exit
         );
         buttonBox.AddChild(
-            new Box(Game, new Vector2(0F, -170F), exitButton)
+            new RelativeBox(Game, (0, 170), exitButton.Size())
             {
-                IsSizeAbsolute = true,
-                IsPositionAbsolute = true,
                 BoxAlignment = Alignments.MiddleCenter,
-                SelfAlignment = Alignments.MiddleCenter
+                SelfAlignment = Alignments.MiddleCenter,
+                DrawableElement = exitButton
             }
         );
         menuBox.AddChild(buttonBox);


### PR DESCRIPTION
Split up Box into RelativeBox and AbsoluteBox.
Create Scalar record instead of using booleans for relative or absolute.

Generally a lot less boilerplate for creating boxes, uses int and float for choosing Pixels or Percent Scalar.
Scalar code contains a lot of implicit operators in order to achieve the magical conversion.

For example if you control click a `0` position you will see that it basically expands to:
```cs
0 -> new(0) -> new(new Pixels(0), new Pixels(0)) -> new ScalarVector2(new Pixels(0), new Pixels(0))
```

With this PR you can mix for example absolute height and relative width:
```cs
(0.5F, 100) -> new ScalarVector2(new Percent(0.5F), new Pixels(100))
```

A `Ratio` Scalar is also added, which can be used on one of the coordinates to say what ratio of the other coordinate for it to be.
A useful example for this is if you want a perfectly square box that is always half the screen height:
```cs
new(new Ratio(1F), 0.5F)
``` 
`Ratio(1F)` here means that the width should always be equal to the height.

You can be fully explicit with defining `ScalarVector2` if you don't like the implicit conversion of `int`, `float`, `tuple` and `Vector2` into `ScalarVector2` with the 22 constructors! 11 implicit operators! and 17 implemented `Pixels` operators with other types!

The constructor that took `UiElement` as a second argument and used it's size is now removed because the compiler kept asking for the second parameter in the constructor to be defined more explicitly in what type it is. This is because there were 2 constructors with the same number of arguments so it couldn't use the implicit definition for the second argument. This caused the whole `ScalarVector2` defining magic to be somewhat lost. Either way I think the slightly more explicit definition with `UiElement.Size()` is not that bad.

Overall GUI now has more flexibility with coordinate independent relative/absolute scalars, and a bit less boilerplate when defining the new `RelativeBox`.